### PR TITLE
fix: use nullable type hint in interpretRules() for PHP 8.4 compatibi…

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -248,7 +248,7 @@ class Rule
         ];
     }
 
-    public function interpretRules(array $conditions = null): string
+    public function interpretRules(?array $conditions = null): string
     {
         if ($conditions === null) {
             $conditions = $this->conditions;


### PR DESCRIPTION
…lity

Replaces `array $conditions = null` with `?array $conditions = null` to resolve the PHP 8.4 deprecation warning. Without this fix, the code would produce a fatal error in PHP 9.0.

Fixes #3